### PR TITLE
Bugfix: Only update package price for the passed package

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,10 +20,10 @@ We have set up a minimal Rails app with some models and tests added. Running rsp
 ```sh
 # Assuming the Rails app is set up and the database is created/migrated
 media_now $ rspec
-....**..*
+**.......*
 
-Finished in 0.06114 seconds (files took 2.5 seconds to load)
-9 examples, 0 failures, 3 pending
+Finished in 0.02163 seconds (files took 0.7978 seconds to load)
+10 examples, 0 failures, 3 pending
 ```
 If all the initially pending tests pass, then you have completed the assignment.
 

--- a/app/services/update_package_price.rb
+++ b/app/services/update_package_price.rb
@@ -7,7 +7,7 @@ class UpdatePackagePrice
       Price.create!(package: package, price_cents: package.price_cents)
 
       # Update the current price
-      Package.update!(price_cents: new_price_cents)
+      package.update!(price_cents: new_price_cents)
     end
   end
 end

--- a/spec/services/update_package_price_spec.rb
+++ b/spec/services/update_package_price_spec.rb
@@ -10,6 +10,17 @@ RSpec.describe UpdatePackagePrice do
     expect(package.reload.price_cents).to eq(200_00)
   end
 
+  it "only updates the passed package price" do
+    package = Package.create!(name: "Dunderhonung")
+    other_package = Package.create!(name: "Farmors köttbullar", price_cents: 100_00)
+
+    expect {
+      UpdatePackagePrice.call(package, 200_00)
+    }.not_to change {
+      other_package.reload.price_cents
+    }
+  end
+
   it "stores the old price of the provided package in its price history" do
     package = Package.create!(name: "Dunderhonung", price_cents: 100_00)
 


### PR DESCRIPTION
Through a code typo, we are accidentally updating *all* package prices instead of just the passed package.