### PR TITLE
Package price per municipality implementation

### DIFF
--- a/app/lib/price_history.rb
+++ b/app/lib/price_history.rb
@@ -1,13 +1,21 @@
 # frozen_string_literal: true
 
 class PriceHistory
-  def self.call(...)
+  def self.call(package, year, **options)
+    beginning_of_year = DateTime.new(year)
+    end_of_year = beginning_of_year.end_of_year
+    all_year = beginning_of_year..end_of_year
 
-    # Feature request 2: Pricing History
-    #
-    # NOTE: Some tests for this file have already been written, but feel free to add
-    # more and change the old tests.
+    prices = package.prices.joins(:municipality).where(created_at: all_year)
+    municipality_name = 'municipalities.name'
 
-    raise NotImplementedError, "Implement this to pass the assignment"
+    if options[:municipality].present?
+      prices = prices.where(municipality: { id: options[:municipality] })
+      municipality_name = 'municipality.name'
+    end
+
+    prices.pluck(municipality_name, :to_price_cents).group_by(&:first).transform_values do |pric|
+      pric.transpose.second
+    end
   end
 end

--- a/app/models/municipality.rb
+++ b/app/models/municipality.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class Municipality < ApplicationRecord
+  has_many :packages, through: :municipalities_packages
+
+  validates :name, presence: true, uniqueness: true
+end

--- a/app/models/municipality.rb
+++ b/app/models/municipality.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Municipality < ApplicationRecord
-  has_many :packages, through: :municipalities_packages
+  has_many :packages, through: :package_municipality_price
 
   validates :name, presence: true, uniqueness: true
 end

--- a/app/models/package.rb
+++ b/app/models/package.rb
@@ -2,6 +2,8 @@
 
 class Package < ApplicationRecord
   has_many :prices, dependent: :destroy
+  has_many :package_municipality_prices
+  has_many :municipalities, through: :package_municipality_price
 
   validates :name, presence: true, uniqueness: true
   validates :price_cents, presence: true

--- a/app/models/package.rb
+++ b/app/models/package.rb
@@ -6,4 +6,8 @@ class Package < ApplicationRecord
   has_many :municipalities, through: :package_municipality_price
 
   validates :name, presence: true, uniqueness: true
+
+  def price_for(municipality_id)
+    package_municipality_prices.find_by(municipality_id: municipality_id)
+  end
 end

--- a/app/models/package.rb
+++ b/app/models/package.rb
@@ -6,5 +6,4 @@ class Package < ApplicationRecord
   has_many :municipalities, through: :package_municipality_price
 
   validates :name, presence: true, uniqueness: true
-  validates :price_cents, presence: true
 end

--- a/app/models/package_municipality_price.rb
+++ b/app/models/package_municipality_price.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class PackageMunicipalityPrice < ApplicationRecord
+  belongs_to :package
+  belongs_to :municipality
+
+  validates :package, uniqueness: { scope: :municipality }
+  validates :price_cents, presence: true
+end

--- a/app/models/price.rb
+++ b/app/models/price.rb
@@ -2,6 +2,7 @@
 
 class Price < ApplicationRecord
   belongs_to :package, optional: false
+  belongs_to :municipality, optional: true
 
   validates :price_cents, presence: true
 end

--- a/app/services/update_package_price.rb
+++ b/app/services/update_package_price.rb
@@ -9,6 +9,7 @@ class UpdatePackagePrice
       Price.create!(
         package: package,
         price_cents: price_for_municipality&.price_cents || package.price_cents,
+        to_price_cents: new_price_cents,
         municipality: price_for_municipality&.municipality
       )
 

--- a/app/services/update_package_price.rb
+++ b/app/services/update_package_price.rb
@@ -3,11 +3,19 @@
 class UpdatePackagePrice
   def self.call(package, new_price_cents, **options)
     Package.transaction do
+      price_for_municipality = package.price_for(options[:municipality]) if options[:municipality].present?
+
       # Add a pricing history record
-      Price.create!(package: package, price_cents: package.price_cents)
+      Price.create!(
+        package: package,
+        price_cents: price_for_municipality&.price_cents || package.price_cents,
+        municipality: price_for_municipality&.municipality
+      )
 
       # Update the current price
       package.update!(price_cents: new_price_cents)
+      # Update the current price for municipality
+      price_for_municipality.update!(price_cents: new_price_cents) if options[:municipality].present?
     end
   end
 end

--- a/db/migrate/20230902123205_create_municipalities.rb
+++ b/db/migrate/20230902123205_create_municipalities.rb
@@ -1,0 +1,11 @@
+class CreateMunicipalities < ActiveRecord::Migration[7.0]
+  def change
+    create_table :municipalities do |t|
+      t.string :name, null: false
+
+      t.timestamps
+    end
+
+    add_index :municipalities, :name, unique: true
+  end
+end

--- a/db/migrate/20230902123808_create_package_municipality_prices.rb
+++ b/db/migrate/20230902123808_create_package_municipality_prices.rb
@@ -1,0 +1,14 @@
+class CreatePackageMunicipalityPrices < ActiveRecord::Migration[7.0]
+  def change
+    create_table :package_municipality_prices do |t|
+      t.belongs_to :package
+      t.belongs_to :municipality
+      t.integer :price_cents, null: false, default: 0
+
+      t.timestamps
+    end
+
+    add_index :package_municipality_prices, [:municipality_id, :package_id], unique: true,
+              name: 'idx_packag_municipality_prices_on_municipality_id_and_packag_id'
+  end
+end

--- a/db/migrate/20230903080950_add_municipality_id_to_prices.rb
+++ b/db/migrate/20230903080950_add_municipality_id_to_prices.rb
@@ -1,0 +1,5 @@
+class AddMunicipalityIdToPrices < ActiveRecord::Migration[7.0]
+  def change
+    add_reference :prices, :municipality, null: true, foreign_key: true
+  end
+end

--- a/db/migrate/20230903081725_change_package_price_to_nullable.rb
+++ b/db/migrate/20230903081725_change_package_price_to_nullable.rb
@@ -1,0 +1,9 @@
+class ChangePackagePriceToNullable < ActiveRecord::Migration[7.0]
+  def up
+    change_column :packages, :price_cents, :integer, null: true
+  end
+
+  def down
+    change_column :packages, :price_cents, :integer, null: false
+  end
+end

--- a/db/migrate/20230903113056_add_to_price_cents_to_prices.rb
+++ b/db/migrate/20230903113056_add_to_price_cents_to_prices.rb
@@ -1,0 +1,5 @@
+class AddToPriceCentsToPrices < ActiveRecord::Migration[7.0]
+  def change
+    add_column :prices, :to_price_cents, :integer, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_09_03_081725) do
+ActiveRecord::Schema.define(version: 2023_09_03_113056) do
 
   create_table "municipalities", force: :cascade do |t|
     t.string "name", null: false
@@ -44,6 +44,7 @@ ActiveRecord::Schema.define(version: 2023_09_03_081725) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.integer "municipality_id"
+    t.integer "to_price_cents", null: false
     t.index ["municipality_id"], name: "index_prices_on_municipality_id"
     t.index ["package_id"], name: "index_prices_on_package_id"
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_09_02_123808) do
+ActiveRecord::Schema.define(version: 2023_09_03_080950) do
 
   create_table "municipalities", force: :cascade do |t|
     t.string "name", null: false
@@ -43,8 +43,11 @@ ActiveRecord::Schema.define(version: 2023_09_02_123808) do
     t.integer "package_id", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.integer "municipality_id"
+    t.index ["municipality_id"], name: "index_prices_on_municipality_id"
     t.index ["package_id"], name: "index_prices_on_package_id"
   end
 
+  add_foreign_key "prices", "municipalities"
   add_foreign_key "prices", "packages"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_09_03_080950) do
+ActiveRecord::Schema.define(version: 2023_09_03_081725) do
 
   create_table "municipalities", force: :cascade do |t|
     t.string "name", null: false
@@ -31,7 +31,7 @@ ActiveRecord::Schema.define(version: 2023_09_03_080950) do
   end
 
   create_table "packages", force: :cascade do |t|
-    t.integer "price_cents", default: 0, null: false
+    t.integer "price_cents"
     t.string "name", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,14 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_01_27_183154) do
+ActiveRecord::Schema.define(version: 2023_09_02_123808) do
+
+  create_table "municipalities", force: :cascade do |t|
+    t.string "name", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["name"], name: "index_municipalities_on_name", unique: true
+  end
 
   create_table "packages", force: :cascade do |t|
     t.integer "price_cents", default: 0, null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -19,6 +19,17 @@ ActiveRecord::Schema.define(version: 2023_09_02_123808) do
     t.index ["name"], name: "index_municipalities_on_name", unique: true
   end
 
+  create_table "package_municipality_prices", force: :cascade do |t|
+    t.integer "package_id"
+    t.integer "municipality_id"
+    t.integer "price_cents", default: 0, null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["municipality_id", "package_id"], name: "idx_packag_municipality_prices_on_municipality_id_and_packag_id", unique: true
+    t.index ["municipality_id"], name: "index_package_municipality_prices_on_municipality_id"
+    t.index ["package_id"], name: "index_package_municipality_prices_on_package_id"
+  end
+
   create_table "packages", force: :cascade do |t|
     t.integer "price_cents", default: 0, null: false
     t.string "name", null: false

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -13,6 +13,12 @@ premium = Package.find_by!(name: "premium")
 plus = Package.find_by!(name: "plus")
 basic = Package.find_by!(name: "basic")
 
+puts "Creating municipalities"
+
+Municipality.insert_all(
+  YAML.load_file(Rails.root.join("import/municipalities.yaml"))
+)
+
 puts "Creating a price history for the packages"
 prices = YAML.load_file(Rails.root.join("import/initial_price_history.yaml"))
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -19,6 +19,37 @@ Municipality.insert_all(
   YAML.load_file(Rails.root.join("import/municipalities.yaml"))
 )
 
+stockholm = Municipality.find_by!(name: "Stockholm")
+gotenburg = Municipality.find_by!(name: "Göteborg")
+malmo = Municipality.find_by!(name: "Malmö")
+
+puts "Creating package prices per municipality"
+package_ids = {}
+package_ids['premium'] = premium.id
+package_ids['plus'] = plus.id
+package_ids['basic'] = basic.id
+
+municipality_ids = {}
+municipality_ids['Stockholm'] = stockholm.id
+municipality_ids['Göteborg'] = gotenburg.id
+municipality_ids['Malmö'] = malmo.id
+
+package_prices_per_municipality = YAML.load_file(Rails.root.join("import/package_municipality_prices.yaml"))
+
+package_prices_per_municipality_arr = package_prices_per_municipality.each_with_object([]) do |(key, value), arr|
+                                        value.each do |package|
+                                          package.each_pair do |name, attrs|
+                                            arr << {
+                                              municipality_id: municipality_ids[key],
+                                              package_id: package_ids[name],
+                                              price_cents: attrs['price_cents']
+                                            }
+                                          end
+                                        end
+                                      end
+
+PackageMunicipalityPrice.insert_all(package_prices_per_municipality_arr)
+
 puts "Creating a price history for the packages"
 prices = YAML.load_file(Rails.root.join("import/initial_price_history.yaml"))
 

--- a/import/municipalities.yaml
+++ b/import/municipalities.yaml
@@ -1,0 +1,4 @@
+---
+- name: "Stockholm"
+- name: "Göteborg"
+- name: "Malmö"

--- a/import/package_municipality_prices.yaml
+++ b/import/package_municipality_prices.yaml
@@ -1,0 +1,22 @@
+---
+Stockholm: 
+  - premium:
+      price_cents: 200_00
+  - plus:
+      price_cents: 599_00
+  - basic:
+      price_cents: 111100
+Göteborg: 
+  - premium:
+      price_cents: 200_00
+  - plus:
+      price_cents: 599_00
+  - basic:
+      price_cents: 111100
+Malmö: 
+  - premium:
+      price_cents: 200_00
+  - plus:
+      price_cents: 599_00
+  - basic:
+      price_cents: 111100

--- a/spec/lib/price_history_spec.rb
+++ b/spec/lib/price_history_spec.rb
@@ -6,37 +6,64 @@ RSpec.describe PriceHistory do
   # These tests cover feature request 2. Feel free to add more tests or change
   # the existing ones.
 
-  xit "returns the pricing history for the provided year and package" do
+  it "returns the pricing history for the provided year and package" do
     basic = Package.create!(name: "basic")
+    stockholm = Municipality.create!(name: "Stockholm")
+    gotenborg = Municipality.create!(name: "Göteborg")
+    package_price_in_stockholm = PackageMunicipalityPrice.create!(
+      package: basic,
+      municipality: stockholm,
+      price_cents: 1235
+    )
+    package_price_in_gotenborg = PackageMunicipalityPrice.create!(
+      package: basic,
+      municipality: gotenborg,
+      price_cents: 1234
+    )
 
     travel_to Time.zone.local(2019) do
       # These should NOT be included
-      UpdatePackagePrice.call(basic, 20_00, municipality: "Stockholm")
-      UpdatePackagePrice.call(basic, 30_00, municipality: "Göteborg")
+      UpdatePackagePrice.call(basic, 20_00, municipality: stockholm.id)
+      UpdatePackagePrice.call(basic, 30_00, municipality: gotenborg.id)
     end
 
     travel_to Time.zone.local(2020) do
-      UpdatePackagePrice.call(basic, 30_00, municipality: "Stockholm")
-      UpdatePackagePrice.call(basic, 40_00, municipality: "Stockholm")
-      UpdatePackagePrice.call(basic, 100_00, municipality: "Göteborg")
+      UpdatePackagePrice.call(basic, 30_00, municipality: stockholm.id)
+      UpdatePackagePrice.call(basic, 40_00, municipality: stockholm.id)
+      UpdatePackagePrice.call(basic, 100_00, municipality: gotenborg.id)
     end
 
-    history = PriceHistory.call(package: basic, year: "2020")
+    history = PriceHistory.call(basic, 2020)
+
     expect(history).to eq(
       "Göteborg" => [100_00],
       "Stockholm" => [30_00, 40_00],
     )
   end
 
-  xit "supports filtering on municipality" do
+  it "supports filtering on municipality" do
     basic = Package.create!(name: "basic")
+    stockholm = Municipality.create!(name: "Stockholm")
+    gotenborg = Municipality.create!(name: "Göteborg")
+    package_price_in_stockholm = PackageMunicipalityPrice.create!(
+      package: basic,
+      municipality: stockholm,
+      price_cents: 1235
+    )
+    package_price_in_gotenborg = PackageMunicipalityPrice.create!(
+      package: basic,
+      municipality: gotenborg,
+      price_cents: 1234
+    )
 
     travel_to Time.zone.local(2020) do
-      UpdatePackagePrice.call(basic, 30_00, municipality: "Stockholm")
-      UpdatePackagePrice.call(basic, 40_00, municipality: "Stockholm")
-      UpdatePackagePrice.call(basic, 100_00, municipality: "Göteborg")
+      UpdatePackagePrice.call(basic, 30_00, municipality: stockholm.id)
+      UpdatePackagePrice.call(basic, 40_00, municipality: stockholm.id)
+      UpdatePackagePrice.call(basic, 100_00, municipality: gotenborg.id)
     end
 
-    # Whoops no assertions, please add some
+    history = PriceHistory.call(basic, 2020, municipality: stockholm.id)
+
+    expect(history).to eq("Stockholm" => [30_00, 40_00])
   end
 end

--- a/spec/models/package_spec.rb
+++ b/spec/models/package_spec.rb
@@ -8,10 +8,4 @@ RSpec.describe Package do
     expect(package.validate).to eq(false)
     expect(package.errors[:name]).to be_present
   end
-
-  it "validates the presence of price_cents" do
-    package = Package.new(price_cents: nil)
-    expect(package.validate).to eq(false)
-    expect(package.errors[:price_cents]).to be_present
-  end
 end

--- a/spec/services/update_package_price_spec.rb
+++ b/spec/services/update_package_price_spec.rb
@@ -4,14 +4,14 @@ require "spec_helper"
 
 RSpec.describe UpdatePackagePrice do
   it "updates the current price of the provided package" do
-    package = Package.create!(name: "Dunderhonung")
+    package = Package.create!(name: "Dunderhonung", price_cents: 100_00)
 
     UpdatePackagePrice.call(package, 200_00)
     expect(package.reload.price_cents).to eq(200_00)
   end
 
   it "only updates the passed package price" do
-    package = Package.create!(name: "Dunderhonung")
+    package = Package.create!(name: "Dunderhonung", price_cents: 100_00)
     other_package = Package.create!(name: "Farmors köttbullar", price_cents: 100_00)
 
     expect {
@@ -33,12 +33,18 @@ RSpec.describe UpdatePackagePrice do
   # This tests covers feature request 1. Feel free to add more tests or change
   # the existing one.
 
-  xit "supports adding a price for a specific municipality" do
-    package = Package.create!(name: "Dunderhonung")
+  it "supports adding a price for a specific municipality" do
+    package = Package.create(name: "Dunderhonung")
+    municipality = Municipality.create(name: 'Göteborg')
+    package_price_in_gotenborg = PackageMunicipalityPrice.create!(
+      package: package,
+      municipality: municipality,
+      price_cents: 1234
+    )
 
-    UpdatePackagePrice.call(package, 200_00, municipality: "Göteborg")
+    UpdatePackagePrice.call(package, 200_00, municipality: municipality.id)
 
     # You'll need to implement Package#price_for
-    expect(package.price_for("Göteborg")).to eq(200_00)
+    expect(package.price_for(municipality.id).price_cents).to eq(200_00)
   end
 end


### PR DESCRIPTION
Both feature requests are implemented in this branch.
All specs are passing.

NOTE: There were errors in tests before the changes, because some packages were created without price, which was then a required field.

(Not required) Changes in the seeds file were made, too.

**Feature request 1: Municipalities**
Since there will be a different price per municipality, a new join table was created, with additional field for the price. All existing functionality was modified to accommodate this change.

_Why there is still a `price_cents` field in packages?_
Municipality may be optional, so the previous functionality should work as is.

_Why 2 foreign keys in the prices and not the id of the join table?_
It is easier for join queries this way.

_Alternative implementation_
There is another way to implement this functionality, by having both package type name and city name as fields in `PackageMunicipalityPrice` model. Their values would be determined from 2 different enums and would correspond to an integer value in the database. This way some of the joins could be avoided.

**Feature request 2: Pricing history**
Since we need the prices to which the intial prices were changed to, an additional field was added to the prices table, in order for each entry to include both the old and the new value for a price. The  I believe that this not only makes the feature get implemented easier, but also any log should contain both the old and new state of something.

**_What I would do with more time_**
- I would add specs for the new validations in every model.
- `PriceHistory` class resembles a service, but isn't one. Either make it one, or move the method elsewhere, where it suits better.
- Initial migration for the `PackageMunicipalityPrice`.
- Initial migration for `Prices`: `to_price_cents` = next.`price_cents` and last.`to_price_cents` = municipality price.`price_cents`
- Some namings are off.
- Code beautification.

